### PR TITLE
Fix: Use jekyll 4.X version

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,0 +1,22 @@
+---
+name: Build and deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # or master before October 2020
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - uses: helaili/jekyll-action@2.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On the current branch, it fails due to the lack of capture on liquid, so
page is not published correctly.

This Action is from current jekyll doc:
https://jekyllrb.com/docs/continuous-integration/github-actions/

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>