### PR TITLE
Build: fix GitHub action version

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -17,6 +17,6 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
-      - uses: helaili/jekyll-action@2.0.5
+      - uses: helaili/jekyll-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Commit 2494a7066b11c888bc4718bba794d5e1c4dbcea1 was not correct at all
and it fails.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>