### PR TITLE
Update doc for `hack/install-agent-dnf.sh`

### DIFF
--- a/documentation/latest/gsg/kind.md
+++ b/documentation/latest/gsg/kind.md
@@ -112,7 +112,7 @@ Now, two scripts are created:
 On the device, with Fedora already installed, we need to execute the following:
 
 ```
-$ hack/install-agent-dnf.sh -i 192.168.2.10
+$ sudo hack/install-agent-dnf.sh -i 192.168.2.10
 ```
 
 Where 192.168.2.10 is your host ip.

--- a/documentation/latest/gsg/minikube.md
+++ b/documentation/latest/gsg/minikube.md
@@ -129,7 +129,7 @@ $ kubectl port-forward service/flotta-operator-controller-manager -n flotta 8043
 On the device, with Fedora already installed, we need to execute the following:
 
 ```
-$ hack/install-agent-dnf.sh -i 192.168.2.10
+$ sudo hack/install-agent-dnf.sh -i 192.168.2.10
 ```
 
 Where 192.168.2.10 is your host ip.


### PR DESCRIPTION
Updated the instructions for running `hack/install-agent-dnf.sh` on minikube and kind.

Signed-off-by: arielireni <aireni@redhat.com>