### PR TITLE
Fix incorrectly rendered make get-certs command

### DIFF
--- a/documentation/latest/dev/installation.md
+++ b/documentation/latest/dev/installation.md
@@ -109,14 +109,14 @@ make run
 For registering devices, it's important to download certs and set correct
 permission:
 
-```shell
+~~~
 $ -> sudo rm /tmp/*.pem
 $ -> make get-certs
 kubectl get secret -n flotta flotta-ca -o go-template='{{ index .data "ca.crt" | base64decode}}' >/tmp/ca.pem
 kubectl get secret -n flotta reg-client-ca-2f5cpqwrhm -o go-template='{{ index .data "client.crt" | base64decode}}' > /tmp/cert.pem
 kubectl get secret -n flotta reg-client-ca-2f5cpqwrhm -o go-template='{{ index .data "client.key" | base64decode}}' > /tmp/key.pem
 $ -> sudo chown root:root /tmp/*.pem
-```
+~~~
 
 ## Device installation
 


### PR DESCRIPTION
Liquid complains about the format of `make get-certs` output:
```
    Liquid Warning: Liquid syntax error (line 111): Expected end_of_string but found string in "{{ index .data "ca.crt" | base64decode}}" in documentation/latest/dev/installation.md                                                                                                                                                           
    Liquid Warning: Liquid syntax error (line 112): Expected end_of_string but found string in "{{ index .data "client.crt" | base64decode}}" in documentation/latest/dev/installation.md                                                                                                                                                       
    Liquid Warning: Liquid syntax error (line 113): Expected end_of_string but found string in "{{ index .data "client.key" | base64decode}}" in documentation/latest/dev/installation.md   
```
and omits the content of go-template:

![Selection_1129](https://user-images.githubusercontent.com/316242/168908190-83660322-2aae-4c6b-aebf-163c155a2857.png)

The PR replaces the back-tick ``` with ~~~ to fix the issue.

Signed-off-by: Moti Asayag <masayag@redhat.com>