### PR TITLE
Update make install-router output

### DIFF
--- a/documentation/latest/gsg/kind.md
+++ b/documentation/latest/gsg/kind.md
@@ -69,6 +69,8 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deplo
 customresourcedefinition.apiextensions.k8s.io/routes.route.openshift.io created
 kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deploy/router.yaml
 deployment.apps/ingress-router created
+kubectl wait --for=condition=Ready pods --all -n openshift-ingress --timeout=60s
+pod/ingress-router-5b9b477c98-gx5pl condition met
 ```
 
 Now let's install Flotta on the cluster:

--- a/documentation/latest/gsg/minikube.md
+++ b/documentation/latest/gsg/minikube.md
@@ -76,6 +76,8 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deplo
 customresourcedefinition.apiextensions.k8s.io/routes.route.openshift.io created
 kubectl apply -f https://raw.githubusercontent.com/openshift/router/master/deploy/router.yaml
 deployment.apps/ingress-router created
+kubectl wait --for=condition=Ready pods --all -n openshift-ingress --timeout=60s
+pod/ingress-router-5b9b477c98-gx5pl condition met
 ```
 
 Now let's install Flotta on the cluster:


### PR DESCRIPTION
`make install-router` waits for a minute for openshift-ingress pod's to
be ready.
Adding the expected command and its output to the sample log.

Signed-off-by: Moti Asayag <masayag@redhat.com>