### PR TITLE
Update device-worker installation step

### DIFF
--- a/documentation/latest/dev/installation.md
+++ b/documentation/latest/dev/installation.md
@@ -140,7 +140,7 @@ and it's defined on workers.toml.
 So for this, on device-worker repo the following command should be run:
 
 ```shell
-sudo make install
+sudo --preserve-env=XDG_RUNTIME_DIR,HOME,USER make install
 ```
 
 This will create two files:


### PR DESCRIPTION
Specify required env-vars in order to set needed variables in
/usr/local/etc/yggdrasil/workers/device-worker.toml for podman to work properly.

Signed-off-by: Moti Asayag <masayag@redhat.com>