### PR TITLE
Theme: add a link on headings

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,3 +39,19 @@
       _satellite.pageBottom();
   }
 </script>
+
+
+<script>
+  $(function() {
+    return $("h2, h3, h4, h5, h6").each(function(i, el) {
+      var $el, icon, id;
+      $el = $(el);
+      id = $el.attr('id');
+      icon = '<i class="ti-link"></i>';
+      console.log("test test"+id)
+      if (id) {
+        return $el.prepend($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
+      }
+    });
+  });
+</script>

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -19,3 +19,8 @@ pre {
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+.header-link {
+  left: -0.5em;
+  color: $text-color-dark;
+}


### PR DESCRIPTION
With this change, all the headings h[1-5] will have a link on the
left, so users have an easy way to link documentation section without
too much trouble.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>