### PR TITLE
Doc: Added plantuml plugin

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM jekyll/jekyll:4.2.2
+
+ENV PLANTUML_VERSION 1.2022.5
+RUN apk add --no-cache graphviz wget ca-certificates ttf-dejavu fontconfig openjdk11 \
+  && wget http://downloads.sourceforge.net/project/plantuml/$PLANTUML_VERSION/plantuml.$PLANTUML_VERSION.jar -O /usr/bin/plantuml.jar \ 
+  && echo '#!/bin/sh' > /usr/bin/plantuml\
+  && echo 'java -jar /usr/bin/plantuml.jar $*' >> /usr/bin/plantuml \
+  && chmod a+rx /usr/bin/plantuml

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -17,7 +17,11 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+
       - uses: helaili/jekyll-action@v2
+        env:
+          PLANTUML_VERSION: "1.2022.5"
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target_branch: gh-pages
+          pre_build_commands: apk add --no-cache graphviz wget ca-certificates ttf-dejavu fontconfig openjdk11 && wget http://downloads.sourceforge.net/project/plantuml/$PLANTUML_VERSION/plantuml.$PLANTUML_VERSION.jar -O /usr/bin/plantuml.jar && echo '#!/bin/sh' > /usr/bin/plantuml && echo 'java -jar /usr/bin/plantuml.jar $*' >> /usr/bin/plantuml && chmod a+rx /usr/bin/plantuml

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "webrick"
 
 gem 'rake'
 gem 'html-proofer'
+gem 'jekyll-plantuml', '~> 1.1'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 JEKYLL_VERSION ?= 4.2.2
 
 CONTAINER_NAME ?= flotta.github.io
-
+IMG=flotta-jekyll
 DOCKER ?= docker
 
 
@@ -25,13 +25,17 @@ help: ## Display this help.
 
 ##@ Build
 
+build-container:
+	$(DOCKER) build -t $(IMG) .docker
+
 build:  ## build the site
-	$(DOCKER) run --rm --volume="$(PWD):/srv/jekyll" jekyll/jekyll:$(JEKYLL_VERSION) jekyll build
+build: build-container
+	$(DOCKER) run --rm --volume="$(PWD):/srv/jekyll" $(IMG) jekyll build
 
 check-links: ## Check that all links are working
 check-links: build
 	$(DOCKER) run --rm -v $(PWD)/_site:/src klakegg/html-proofer:3.19.2 --allow-hash-href --empty-alt-ignore --disable-external
 
 run: build ## run the site on localhost:3000
-	$(DOCKER) run --rm --name $(CONTAINER_NAME) --volume="$(PWD):/srv/jekyll" -p 3000:4000 -it jekyll/jekyll:$(JEKYLL_VERSION) jekyll serve --watch --drafts 
+	$(DOCKER) run --rm --name $(CONTAINER_NAME) --volume="$(PWD):/srv/jekyll" -p 3000:4000 -it $(IMG) jekyll serve --watch --drafts 
 

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ plugins:
   - jekyll-redirect-from
   - jekyll-mermaid
   - jekyll-relative-links
+  - jekyll-plantuml
 
 sass:
   sass_dir: assets/scss

--- a/documentation/latest/operations/data_upload.md
+++ b/documentation/latest/operations/data_upload.md
@@ -11,7 +11,29 @@ on-device directories to control-plane object storage. User can choose between
 in-cluster OCS storage or external storage. OCS takes precedence over external
 storage. The architecture of that solution is depicted by the diagrams below.
 
-![](../diagrams/data-upload.png)
+{% plantuml %}
+@startuml
+
+frame Kubernetes {
+    component "Flotta Operator" as operator
+    component "Flotta Edge API" as edgeAPI
+    database "Object Bucket Claim" as buckets
+    interface S3
+}
+
+frame "Edge Device" {
+    node "Flotta Agent" as deviceAgent
+}
+
+buckets -down- S3: API
+deviceAgent --> S3: Upload files
+deviceAgent -up---> edgeAPI : Get configuration
+
+operator --> buckets: Provision
+
+@enduml
+
+{% endplantuml %}
 
 ## OCS storage
 


### PR DESCRIPTION
With this change plantuml can be now loaded inline in the docs,
something that adds a better way to version across multiple versions of
flotta-operators.

The way to use is the following:

```
{% plantuml %}
[First] - [Second]
{% endplantuml %}
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>