### PR TITLE
blog: mention requiered operator version

### DIFF
--- a/_posts/2022-04-15-flotta-and-raspberry-pi.markdown
+++ b/_posts/2022-04-15-flotta-and-raspberry-pi.markdown
@@ -18,6 +18,10 @@ sensors deployment, vehicle deployment or many other cases.
 
 Let's learn how Flotta can be used to manage it by following steps described in this article.
 
+## Prerequisite
+
+- Installed Flotta-Operator with a version higher than v0.1.0.
+
 ## Fedora IoT on Raspberry Pi 4 installation
 
 1) Download [Fedora IoT 35 Raw Image](https://download.fedoraproject.org/pub/alt/iot/35/IoT/aarch64/images/Fedora-IoT-35-20220101.0.aarch64.raw.xz)
@@ -64,8 +68,6 @@ Options used:
 
   ![Raspberry Pi 4](/assets/images/rpi4.jpg)
   ![Booted RPI4](/assets/images/rpi4_up.jpg)
-
-- Flotta Operator installed in a Kuberenetes Cluster - follow [operator installation instructions](https://github.com/project-flotta/flotta-operator/blob/main/docs/user-guide/running.md#operator).
 
 ### Installation
 


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

It seems that the last version of the operator ([v0.1.0](https://github.com/project-flotta/flotta-operator/releases/tag/v0.1.0)) does not provide an `service/flotta-edge-api`. But this is needed in the later course of the tutorial.

After switch to latest, it worked so far. 
```bash
make deploy IMG=quay.io/project-flotta/flotta-operator:latest HTTP_IMG=quay.io/project-flotta/flotta-edge-api:latest TARGET=k8s
```