### PR TITLE
Fix: V0.2 release missing pieces

### DIFF
--- a/documentation/v0_2_0/gsg/kind.md
+++ b/documentation/v0_2_0/gsg/kind.md
@@ -51,7 +51,7 @@ Flotta operator has a few tools that helps to install flotta, for that, let's
 clone it:
 
 ```shell
-git clone https://github.com/project-flotta/flotta-operator -b main --depth 1
+git clone https://github.com/project-flotta/flotta-operator -b v0.2.0 --depth 1
 cd flotta-operator
 ```
 
@@ -76,7 +76,7 @@ pod/ingress-router-5b9b477c98-gx5pl condition met
 Now let's install Flotta on the cluster:
 
 ```shell
-$ -> make deploy IMG=quay.io/project-flotta/flotta-operator:latest HTTP_IMG=quay.io/project-flotta/flotta-edge-api:latest TARGET=k8s
+$ -> make deploy IMG=quay.io/project-flotta/flotta-operator:v0.2.0 HTTP_IMG=quay.io/project-flotta/flotta-edge-api:v0.2.0 TARGET=k8s
 ```
 
 A bunch of CRDs are now created, where the definitions can be found

--- a/documentation/v0_2_0/gsg/minikube.md
+++ b/documentation/v0_2_0/gsg/minikube.md
@@ -58,7 +58,7 @@ Flotta operator has a few tools that helps to install flotta, for that, let's
 clone it:
 
 ```shell
-git clone https://github.com/project-flotta/flotta-operator -b main --depth 1
+git clone https://github.com/project-flotta/flotta-operator -b v0.2.0 --depth 1
 cd flotta-operator
 ```
 
@@ -83,7 +83,7 @@ pod/ingress-router-5b9b477c98-gx5pl condition met
 Now let's install Flotta on the cluster:
 
 ```shell
-make deploy IMG=quay.io/project-flotta/flotta-operator:latest HTTP_IMG=quay.io/project-flotta/flotta-edge-api:latest TARGET=k8s
+make deploy IMG=quay.io/project-flotta/flotta-operator:v0.2.0 HTTP_IMG=quay.io/project-flotta/flotta-edge-api:v0.2.0 TARGET=k8s
 
 ```
 

--- a/documentation/v0_2_0/gsg/ocp.md
+++ b/documentation/v0_2_0/gsg/ocp.md
@@ -25,7 +25,7 @@ Flotta operator has a few tools that helps to install flotta, for that, let's
 clone it:
 
 ```shell
-git clone https://github.com/project-flotta/flotta-operator -b main --depth 1
+git clone https://github.com/project-flotta/flotta-operator -b v0.2.0 --depth 1
 cd flotta-operator
 ```
 

--- a/documentation/v0_2_0/operations/api.html
+++ b/documentation/v0_2_0/operations/api.html
@@ -13,7 +13,7 @@ title: API  reference
 window.onload = function() {
 
   window.ui = SwaggerUIBundle({
-    url: "https://raw.githubusercontent.com/project-flotta/flotta-operator/main/swagger.yaml",
+    url: "https://raw.githubusercontent.com/project-flotta/flotta-operator/v0.2.0/swagger.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
On commit f2923b2b021748fd942a9027bd61abd1c5151d4c new v2 images where
created, but not all steps documented in the readme were done, this
commit address the following:

```
- [x] cp _data/documentation/latest.yaml _data/documentation/$VERSION.yaml
- [x] cp -rfv /documentation/latest /documentation/$VERSION
- [x] edit /documentation/$VERSION/gsg/*.md and change the following:
  - git clone commands to the right version.
  - make deploy with the right container version
- [x] edit /documentation/$VERSION/operations/api.html and change the swagger URL
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>