### PR TITLE
Add debugging bad certificates to flotta-dev-cli

### DIFF
--- a/_posts/2022-07-20-developer-cli.markdown
+++ b/_posts/2022-07-20-developer-cli.markdown
@@ -3,7 +3,7 @@ layout: post
 title: "Flotta Developer CLI"
 date: 2022-07-20 12:00:00 +1000
 categories: flotta
-author: Ariel Ireni
+author: Ariel Ireni, Moti Asayag
 tags:
 - guide
 - flotta
@@ -106,6 +106,16 @@ As things might not always be clear, here are some tips to help you:
 * Workloads are run under the _flotta_ user. Workloads debugging needs to be done also as _flotta_ user on the device.
 
 ### Debug the device
+In order to register the device, the Flotta Edge API certificates need to be used to establish communication. To download the certificates run the following from flotta-operator project:
+```shell
+# remove old certs, if exists
+$ sudo rm /tmp/*.pem
+# download new certs, from the flotta operator project
+$ make get-certs
+# set permissions
+$ sudo chown root:root /tmp/*.pem
+```
+
 To connect to a device, use docker command to list the running edge device containers and their status:
 ```shell
 → docker ps --filter label=flotta


### PR DESCRIPTION
Added documentation on updating the certificates under troubleshooting -> debug the device section.

Signed-off-by: arielireni <aireni@redhat.com>